### PR TITLE
to see if fixes #12186

### DIFF
--- a/lib/windows/winlean.nim
+++ b/lib/windows/winlean.nim
@@ -747,7 +747,7 @@ proc getFileSize*(hFile: Handle, lpFileSizeHigh: ptr DWORD): DWORD{.stdcall,
 
 proc mapViewOfFileEx*(hFileMappingObject: Handle, dwDesiredAccess: DWORD,
                       dwFileOffsetHigh, dwFileOffsetLow: DWORD,
-                      dwNumberOfBytesToMap: DWORD,
+                      dwNumberOfBytesToMap: uint,
                       lpBaseAddress: pointer): pointer{.
     stdcall, dynlib: "kernel32", importc: "MapViewOfFileEx".}
 


### PR DESCRIPTION
`mapViewOfFileEx` of `winlean.nim` has wrong FFI declaration #12186
dwNumberOfBytesToMap is assigned DWORD type. but according to official doc it should be SIZE_T.

SIZE_T is uint32 on 32-bit target and uint64 on 64-bit target.